### PR TITLE
Enterprise 3.0.3 r2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Triton-optimized Couchbase
 #
-FROM 		centos:6
+FROM 		centos:centos6.6
 MAINTAINER 	Casey Bisson <casey.bisson@gmail.com>
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,41 @@
 #
 # Triton-optimized Couchbase
 #
-FROM 		couchbase/server:enterprise-3.0.3
+FROM 		centos:6
 MAINTAINER 	Casey Bisson <casey.bisson@gmail.com>
 
-# installed Node.js, similar to https://github.com/joyent/docker-node/blob/428d5e69763aad1f2d8f17c883112850535e8290/0.12/Dockerfile
+#
+# Install yum dependencies
+#
+RUN yum install -y tar \
+    && yum clean all
+
+#
+# Install gosu for startup script
+#
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -sSL "https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
+
+#
+# Set Couchbase install vars
+#
+ENV CB_VERSION=3.0.3 \
+    CB_RELEASE_URL=http://packages.couchbase.com/releases \
+    CB_PACKAGE=couchbase-server-enterprise-3.0.3-centos6.x86_64.rpm \
+    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+
+# Install Couchbase
+RUN rpm --install $CB_RELEASE_URL/$CB_VERSION/$CB_PACKAGE
+
+
+#
+# Install Node.js
+# similar to https://github.com/joyent/docker-node/blob/428d5e69763aad1f2d8f17c883112850535e8290/0.12/Dockerfile
+#
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
 ENV NODE_VERSION 0.12.4
@@ -19,12 +50,21 @@ RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear
 
+#
+# Install the json tool
+#
 RUN npm install -g json
 
+#
+# Start scripts
+#
 COPY bin/* /usr/local/bin/
 
+#
+# Metadata
+#
 EXPOSE 8091 8092 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var
-
 ENTRYPOINT ["triton-start"]
+# pass -noinput so it doesn't drop us in the erlang shell
 CMD ["couchbase-server", "--", "-noinput"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Triton-optimized Couchbase
+
+Read [the blog post](https://www.joyent.com/blog/couchbase-in-docker-containers) and the [Docker Compose yaml](https://github.com/misterbisson/clustered-couchbase-in-containers) to better understand how to use this image.

--- a/bin/couchbase-start
+++ b/bin/couchbase-start
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Couchbase Server start script. 
+
+set -e
+
+if [ "$1" = 'couchbase-server' ]
+then
+
+    if [ "$(id -u)" != "0" ]; then
+        echo "This script must be run as root"
+        exit 1
+    fi
+
+    # Create directories where couchbase stores its data
+    cd /opt/couchbase
+    mkdir -p var/lib/couchbase \
+        var/lib/couchbase/config \
+        var/lib/couchbase/data \
+        var/lib/couchbase/stats \
+        var/lib/couchbase/logs \
+        var/lib/moxi
+    chown -R couchbase:couchbase var
+
+    # Start couchbase
+    echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091"
+    exec gosu couchbase "$@"
+fi
+
+exec "$@"

--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -89,6 +89,12 @@ else
     echo '#'
 fi
 
+#
+# Register this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
+#
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s"}' $MYIPPRIVATE $MYIPPRIVATE)"
+
+
 COUCHBASERESPONSIVE=0
 while [ $COUCHBASERESPONSIVE != 1 ]; do
     echo -n '.'
@@ -139,6 +145,11 @@ then
     echo '#'
     echo '# Bootstrapping cluster'
     echo '#'
+
+    #
+    # Deregister this instance from the list of unconfigured instances in Consul
+    #
+    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$MYIPPRIVATE
 
     # initializing the cluster
     COUCHBASERESPONSIVE=0
@@ -203,6 +214,10 @@ else
         fi
     done
 
+    #
+    # Deregister this instance from the list of unconfigured instances in Consul
+    #
+    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$MYIPPRIVATE
 
     echo
     echo '#'
@@ -269,9 +284,11 @@ done
 
 echo
 echo '#'
-echo '# Registering service instance'
+echo '# Register the configured Couchbase instance'
 echo '#'
 
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-%s","Name":"couchbase","Address":"%s"}' $MYIPPRIVATE $MYIPPRIVATE)"
+# Note that the healthcheck
+
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID": "couchbase-%s","Name": "couchbase","tags": ["couchbase","demo"],"Address": "%s","checks": [{"http": "http://%s:8091/index.html","interval": "13s","timeout": "1s"}]}' $MYIPPRIVATE $MYIPPRIVATE $MYIPPRIVATE)"
 
 installed

--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -205,7 +205,7 @@ else
     while [ $CLUSTERFOUND != 1 ]; do
         echo -n '.'
 
-        CLUSTERIP=$(curl -L -s -f http://consul:8500/v1/catalog/service/couchbase | json -aH ServiceAddress | head -1)
+        CLUSTERIP=$(curl -L -s -f curl http://consul:8500/v1/health/service/couchbase?passing | json -aH Service.Address | head -1)
         if [ -n "$CLUSTERIP" ]
         then
             let CLUSTERFOUND=1

--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail
+.DEFAULT_GOAL := build
+
+TAG?=latest
+
+# run the Docker build
+build:
+	docker build -t="misterbisson/triton-couchbase:${TAG}" .
+
+# push our image to the public registry
+ship: build
+	docker push "misterbisson/triton-couchbase:${TAG}"
+


### PR DESCRIPTION
- Rewrote Dockerfile to _not_ use `couchbase/server:enterprise-3.0.3` as the base image because breaking changes were pushed there. See more in the specific commits.
- Added support for healthchecks
- Now register the Couchbase node in Consul while it's awaiting configuration, then remove and re-register it as a proper healthy node when it's configured and joined to the cluster.
