### PR TITLE
Additions to help use in Mesos+Marathon

### DIFF
--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -92,7 +92,11 @@ fi
 #
 # Register this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
 #
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "59s"}]}' $HOSTNAME $MYIPPRIVATE)"
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "5900s"}]}' $HOSTNAME $MYIPPRIVATE)"
+
+# pass the healthcheck
+curl -f --retry 7 --retry-delay 3 "http://consul:8500/v1/agent/check/pass/service:couchbase-unconfigured-$HOSTNAME?note=initial+startup"
+
 
 
 COUCHBASERESPONSIVE=0
@@ -210,8 +214,8 @@ else
         then
             let CLUSTERFOUND=1
         else
-            # Renew the registration of this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
-            curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "29"}]}' $HOSTNAME $MYIPPRIVATE)"
+            # Update the healthcheck for this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
+            curl -f --retry 7 --retry-delay 3 "http://consul:8500/v1/agent/check/pass/service:couchbase-unconfigured-$HOSTNAME?note=polling+for+cluster"
 
             # sleep for a bit
             sleep 7

--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -92,7 +92,7 @@ fi
 #
 # Register this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
 #
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s"}' $HOSTNAME $MYIPPRIVATE)"
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "211s"}]}' $HOSTNAME $MYIPPRIVATE)"
 
 
 COUCHBASERESPONSIVE=0
@@ -205,7 +205,7 @@ else
     while [ $CLUSTERFOUND != 1 ]; do
         echo -n '.'
 
-        CLUSTERIP=$(curl -L -s -f curl http://consul:8500/v1/health/service/couchbase?passing | json -aH Service.Address | head -1)
+        CLUSTERIP=$(curl -L -s -f http://consul:8500/v1/health/service/couchbase?passing | json -aH Service.Address | head -1)
         if [ -n "$CLUSTERIP" ]
         then
             let CLUSTERFOUND=1

--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -92,7 +92,7 @@ fi
 #
 # Register this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
 #
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "211s"}]}' $HOSTNAME $MYIPPRIVATE)"
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "59s"}]}' $HOSTNAME $MYIPPRIVATE)"
 
 
 COUCHBASERESPONSIVE=0
@@ -210,6 +210,10 @@ else
         then
             let CLUSTERFOUND=1
         else
+            # Renew the registration of this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
+            curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s","checks": [{"ttl": "29"}]}' $HOSTNAME $MYIPPRIVATE)"
+
+            # sleep for a bit
             sleep 7
         fi
     done

--- a/bin/triton-bootstrap
+++ b/bin/triton-bootstrap
@@ -92,7 +92,7 @@ fi
 #
 # Register this unconfigured Couchbase instance in Consul for discovery by the configuration/bootstrap agent
 #
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s"}' $MYIPPRIVATE $MYIPPRIVATE)"
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID":"couchbase-unconfigured-%s","Name":"couchbase-unconfigured","Address":"%s"}' $HOSTNAME $MYIPPRIVATE)"
 
 
 COUCHBASERESPONSIVE=0
@@ -149,7 +149,7 @@ then
     #
     # Deregister this instance from the list of unconfigured instances in Consul
     #
-    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$MYIPPRIVATE
+    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$HOSTNAME
 
     # initializing the cluster
     COUCHBASERESPONSIVE=0
@@ -217,7 +217,7 @@ else
     #
     # Deregister this instance from the list of unconfigured instances in Consul
     #
-    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$MYIPPRIVATE
+    curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/deregister/couchbase-unconfigured-$HOSTNAME
 
     echo
     echo '#'
@@ -289,6 +289,6 @@ echo '#'
 
 # Note that the healthcheck
 
-curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID": "couchbase-%s","Name": "couchbase","tags": ["couchbase","demo"],"Address": "%s","checks": [{"http": "http://%s:8091/index.html","interval": "13s","timeout": "1s"}]}' $MYIPPRIVATE $MYIPPRIVATE $MYIPPRIVATE)"
+curl -f --retry 7 --retry-delay 3 http://consul:8500/v1/agent/service/register -d "$(printf '{"ID": "couchbase-%s","Name": "couchbase","tags": ["couchbase","demo"],"Address": "%s","checks": [{"http": "http://%s:8091/index.html","interval": "13s","timeout": "1s"}]}' $HOSTNAME $MYIPPRIVATE $MYIPPRIVATE)"
 
 installed


### PR DESCRIPTION
- Register in Consul with the Docker container's hostname
- Register a ttl health check for the container awaiting configuration

Together, those make it easier to find Couchbase instances that are awaiting configuration, then get info about them by container ID via the Docker API.
