### PR TITLE
Add telemetry to Couchbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Autopilot pattern Couchbase
-FROM 		couchbase/server:enterprise-4.0.0
+FROM couchbase/server:enterprise-4.0.0
 
 # install jq
 RUN apt-get update && \
@@ -7,13 +7,13 @@ RUN apt-get update && \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Add Containerbuddy
-ENV CONTAINERBUDDY_VER 1.3.0
+# get Containerbuddy release
+ENV CONTAINERBUDDY_VERSION 1.4.0-rc3
 ENV CONTAINERBUDDY file:///etc/containerbuddy.json
 
-RUN export CB_SHA1=c25d3af30a822f7178b671007dcd013998d9fae1 \
+RUN export CB_SHA1=24a2babaff53e9829bcf4772cfe0462f08838a11 \
     && curl -Lso /tmp/containerbuddy.tar.gz \
-         "https://github.com/joyent/containerbuddy/releases/download/${CONTAINERBUDDY_VER}/containerbuddy-${CONTAINERBUDDY_VER}.tar.gz" \
+         "https://github.com/joyent/containerbuddy/releases/download/${CONTAINERBUDDY_VERSION}/containerbuddy-${CONTAINERBUDDY_VERSION}.tar.gz" \
     && echo "${CB_SHA1}  /tmp/containerbuddy.tar.gz" | sha1sum -c \
     && tar zxf /tmp/containerbuddy.tar.gz -C /bin \
     && rm /tmp/containerbuddy.tar.gz

--- a/bin/manage.sh
+++ b/bin/manage.sh
@@ -179,6 +179,15 @@ initCluster() {
     exit 0
 }
 
+# filters JSON coming back from REST API for this node with argument. examples:
+# stats mcdMemoryAllocated
+# stats systemStats.mem_free
+stats() {
+    curl -s -u ${COUCHBASE_USER}:${COUCHBASE_PASS} \
+         http://127.0.0.1:8091/pools/default | \
+        jq -r "$(printf '.nodes[] | select(.hostname | contains("%s")) | .%s' "${IP_PRIVATE}" "$1")"
+}
+
 
 # -------------------------------------------
 # helpers
@@ -192,7 +201,7 @@ checkLock() {
 }
 
 cleanup() {
-    rmdir /var/lock/couchbase-init
+    rm -rf /var/lock/couchbase-init
 }
 
 # -------------------------------------------

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -15,5 +15,31 @@
       "poll": 5,
       "ttl": 15
     }
-  ]
+  ],
+  "telemetry": {
+    "port": 9090,
+    "sensors": [
+      {
+        "name": "couchbase_cpu_utilization",
+        "help": "Couchbase CPU utilization rate",
+        "type": "gauge",
+        "poll": 5,
+        "check": ["/usr/local/bin/manage.sh", "stats", "systemStats.cpu_utilization_rate"]
+      },
+      {
+        "name": "couchbase_mem_free",
+        "help": "Couchbase node memory free",
+        "type": "gauge",
+        "poll": 5,
+        "check": ["/usr/local/bin/manage.sh", "stats", "systemStats.mem_free"]
+      },
+      {
+        "name": "couchbase_swap_used",
+        "help": "Couchbase swap usage",
+        "type": "gauge",
+        "poll": 5,
+        "check": ["/usr/local/bin/manage.sh", "stats", "systemStats.swap_used"]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
@misterbisson this PR adds a couple examples of metrics collection using our new telemetry feature. A running node coughs up telemetry that looks like this:

```
$ curl -s 172.17.0.3:9090/metrics | grep couch
# HELP couchbase_cpu_utilization Couchbase CPU utilization rate
# TYPE couchbase_cpu_utilization gauge
couchbase_cpu_utilization 0.5050505050505051
# HELP couchbase_mem_free Couchbase node memory free
# TYPE couchbase_mem_free gauge
couchbase_mem_free 3.338223616e+09
# HELP couchbase_swap_used Couchbase swap usage
# TYPE couchbase_swap_used gauge
couchbase_swap_used 0
```
