### PR TITLE
Force sensors to exit with non-zero exit code if failing

### DIFF
--- a/bin/manage.sh
+++ b/bin/manage.sh
@@ -183,7 +183,7 @@ initCluster() {
 # stats mcdMemoryAllocated
 # stats systemStats.mem_free
 stats() {
-    curl -s -u ${COUCHBASE_USER}:${COUCHBASE_PASS} \
+    curl -s --fail -u ${COUCHBASE_USER}:${COUCHBASE_PASS} \
          http://127.0.0.1:8091/pools/default | \
         jq -r "$(printf '.nodes[] | select(.hostname | contains("%s")) | .%s' "${IP_PRIVATE}" "$1")"
 }


### PR DESCRIPTION
@misterbisson this will force the sensors for Couchbase to bomb-out if the Couchbase isn't quite running yet, which makes them return a non-zero exit code and not get parsed by ContainerPilot.
