### PR TITLE
Add COUCHBASE_SERVICES option and fix non-linted (shellcheck) code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each time the [`health` handler](https://github.com/autopilotpattern/couchbase/b
 1. Is another node in the middle of bootstrapping the cluster? If so, wait for it and then join to it.
 1. Otherwise, bootstrap the cluster but let any other nodes know that we're doing it by writing a lock in Consul.
 
-### Getting started
+### Setting up with Triton (optional)
 
 1. [Get a Joyent account](https://my.joyent.com/landing/signup/) and [add your SSH key](https://docs.joyent.com/public-cloud/getting-started).
 1. Install the [Docker Toolbox](https://docs.docker.com/installation/mac/) (including `docker` and `docker-compose`) on your laptop or other environment, as well as the [Joyent Triton CLI](https://www.joyent.com/blog/introducing-the-triton-command-line-tool) (`triton` replaces our old `sdc-*` CLI tools)
@@ -30,7 +30,9 @@ curl -O https://raw.githubusercontent.com/joyent/sdc-docker/master/tools/sdc-doc
 ./sdc-docker-setup.sh -k us-east-1.api.joyent.com <ACCOUNT> ~/.ssh/<PRIVATE_KEY_FILE>
 ```
 
-Check that everything is configured correctly by running `./setup.sh`. If it returns without an error you're all set. This script will create and `_env` file that includes the Triton CNS name for the Consul service. You'll want to edit this file to update the username and password for Couchbase.
+### Getting started
+
+Check that everything is configured correctly by running `./setup.sh`. If it returns without an error you're all set. This script will create and `_env` file that includes the Triton CNS name for the Consul service if using Triton. You'll want to edit this file to update the username and password for Couchbase.
 
 ### Running the cluster
 

--- a/demo.sh
+++ b/demo.sh
@@ -18,19 +18,19 @@ CONSUL="$(triton ip ${PREFIX}_consul_1):8500"
 echo
 echo 'Consul is now running'
 echo "Dashboard: $CONSUL"
-command -v open >/dev/null 2>&1 && `open http://$CONSUL/ui/`
+command -v open >/dev/null 2>&1 && open "http://$CONSUL/ui/"
 
 CBDASHBOARD="$(triton ip ${PREFIX}_couchbase_1):8091"
 echo
 echo 'Couchbase cluster running and bootstrapped'
 echo "Dashboard: $CBDASHBOARD"
-command -v open >/dev/null 2>&1 && `open http://$CBDASHBOARD/index.html#sec=servers`
+command -v open >/dev/null 2>&1 && open "http://$CBDASHBOARD/index.html#sec=servers"
 
 echo
 echo 'Creating couchbase bucket'
 # we're specifying a bucket with 2 replicas and using 70% of the 4096MB
 # we specified for the container in our docker-compose.yml
-curl -s -XPOST -u ${COUCHBASE_USER}:${COUCHBASE_PASS} \
+curl -s -XPOST -u "${COUCHBASE_USER}:${COUCHBASE_PASS}" \
      -d 'name=couchbase' \
      -d 'authType=none' \
      -d 'ramQuotaMB=2856' \

--- a/setup.sh
+++ b/setup.sh
@@ -67,8 +67,10 @@ check() {
     }
 
     # make sure Docker client is pointed to the same place as the Triton client
-    local docker_user=$(docker info 2>&1 | awk -F": " '/SDCAccount:/{print $2}')
-    local docker_dc=$(echo $DOCKER_HOST | awk -F"/" '{print $3}' | awk -F'.' '{print $1}')
+    local docker_user
+    docker_user=$(docker info 2>&1 | awk -F": " '/SDCAccount:/{print $2}')
+    local docker_dc
+    docker_dc=$(echo "$DOCKER_HOST" | awk -F"/" '{print $3}' | awk -F'.' '{print $1}')
     TRITON_USER=$(triton profile get | awk -F": " '/account:/{print $2}')
     TRITON_DC=$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')
     TRITON_ACCOUNT=$(triton account get | awk -F": " '/id:/{print $2}')
@@ -86,7 +88,8 @@ check() {
         exit 1
     fi
 
-    local triton_cns_enabled=$(triton account get | awk -F": " '/cns/{print $2}')
+    local triton_cns_enabled
+    triton_cns_enabled=$(triton account get | awk -F": " '/cns/{print $2}')
     if [ ! "true" == "$triton_cns_enabled" ]; then
         echo
         tput rev  # reverse
@@ -99,11 +102,16 @@ check() {
 
     if [ ! -f "_env" ]; then
         echo "Creating a configuration file..."
-        echo 'COUCHBASE_USER=' > _env
-        echo 'COUCHBASE_PASS=' >> _env
-        echo >> _env
-        echo CONSUL=consul.svc.${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com >> _env
-        echo 'Edit the _env file to include a COUCHBASE_USER and COUCHBASE_PASS'
+        {
+            echo 'COUCHBASE_USER='
+            echo 'COUCHBASE_PASS='
+            echo 'COUCHBASE_SERVICES='
+            echo ''
+            if [ ! -z "$TRITON_ACCOUNT" ]; then
+                echo "CONSUL=consul.svc.${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com"
+            fi
+        } > _env
+        echo 'Edit the _env file to include a COUCHBASE_USER, COUCHBASE_PASS and COUCHBASE_SERVICES (optional)'
     fi
 }
 
@@ -116,7 +124,7 @@ while getopts "f:p:h" optchar; do
         p) export COMPOSE_PROJECT_NAME=${OPTARG} ;;
     esac
 done
-shift $(expr $OPTIND - 1 )
+shift $((OPTIND - 1))
 
 until
     cmd=$1

--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,7 @@ check() {
     TRITON_USER=$(triton profile get | awk -F": " '/account:/{print $2}')
     TRITON_DC=$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')
     TRITON_ACCOUNT=$(triton account get | awk -F": " '/id:/{print $2}')
-    if [ ! "$docker_user" = "$TRITON_USER" ] || [ ! "$docker_dc" = "$TRITON_DC" ]; then
+    if [ ! -z "$TRITON_ACCOUNT" ] && [ ! "$docker_user" = "$TRITON_USER" ] || [ ! "$docker_dc" = "$TRITON_DC" ]; then
         echo
         tput rev  # reverse
         tput bold # bold

--- a/setup.sh
+++ b/setup.sh
@@ -71,9 +71,9 @@ check() {
     docker_user=$(docker info 2>&1 | awk -F": " '/SDCAccount:/{print $2}')
     local docker_dc
     docker_dc=$(echo "$DOCKER_HOST" | awk -F"/" '{print $3}' | awk -F'.' '{print $1}')
-    TRITON_USER=$(triton profile get | awk -F": " '/account:/{print $2}')
-    TRITON_DC=$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')
-    TRITON_ACCOUNT=$(triton account get | awk -F": " '/id:/{print $2}')
+    TRITON_USER=$(triton profile get 2>/dev/null | awk -F": " '/account:/{print $2}' 2>/dev/null) || true
+    TRITON_DC=$(triton profile get 2>/dev/null | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}' 2>/dev/null) || true
+    TRITON_ACCOUNT=$(triton account get 2>/dev/null | awk -F": " '/id:/{print $2}' 2>/dev/null) || true
     if [ ! -z "$TRITON_ACCOUNT" ] && [ ! "$docker_user" = "$TRITON_USER" ] || [ ! "$docker_dc" = "$TRITON_DC" ]; then
         echo
         tput rev  # reverse
@@ -89,8 +89,8 @@ check() {
     fi
 
     local triton_cns_enabled
-    triton_cns_enabled=$(triton account get | awk -F": " '/cns/{print $2}')
-    if [ ! "true" == "$triton_cns_enabled" ]; then
+    triton_cns_enabled=$(triton account get 2>/dev/null | awk -F": " '/cns/{print $2}') || true
+    if [ ! -z "$TRITON_ACCOUNT" ] && [ ! "true" == "$triton_cns_enabled" ]; then
         echo
         tput rev  # reverse
         tput bold # bold


### PR DESCRIPTION
COUCHBASE_SERVICES now able to be passed through as an env variable and includes validation for the service types.

I also did a lint check on the bash scripts and fixed some reported warnings from [shellcheck](shellcheck.net).

Also ensured that image setup could be run against a local docker installation as well as Triton.
